### PR TITLE
Take port and tls from env var

### DIFF
--- a/code/utilities/redisembeddings.py
+++ b/code/utilities/redisembeddings.py
@@ -103,7 +103,7 @@ def get_prompt_results(number_of_results: int=VECT_NUMBER):
         return pd.DataFrame()
 
 # Connect to the Redis server
-redis_conn = Redis(host= os.environ.get('REDIS_ADDRESS','localhost'), port=6379, password=os.environ.get('REDIS_PASSWORD',None)) #api for Docker localhost for local execution
+redis_conn = Redis(host= os.environ.get('REDIS_ADDRESS','localhost'), port=os.environ.get('REDIS_PORT',6379), password=os.environ.get('REDIS_PASSWORD',None), ssl=os.environ.get('REDIS_TLS',False)) #api for Docker localhost for local execution
 
 # Check if Redis index exists
 index_name = "embeddings-index"


### PR DESCRIPTION
When I want to set my port to another Redis cache, I cannot change the port. I also cannot enable tls.
This change lets me set the redis port in the environment variables and lets me enable/disable tls from the env vars.