### PR TITLE
Default .env.template to use text-embedding-ada-002

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 OPENAI_ENGINES=text-davinci-002,text-curie-001,text-babbage-001,text-ada-001
-OPENAI_EMBEDDINGS_ENGINE_DOC=text-search-davinci-doc-001 
-OPENAI_EMBEDDINGS_ENGINE_QUERY=text-search-davinci-query-001
+OPENAI_EMBEDDINGS_ENGINE_DOC=text-embedding-ada-002
+OPENAI_EMBEDDINGS_ENGINE_QUERY=text-embedding-ada-002
 OPENAI_API_BASE=https://YOUR_AZURE_OPENAI_RESOURCE.openai.azure.com/
 OPENAI_API_KEY=YOUR_AZURE_OPENAI_API_KEY
 REDIS_ADDRESS=api


### PR DESCRIPTION
When you follow the documentation for a local Docker setup, it will copy the `.env.template` which has outdated values. Best would be to have the new models mentioned there as well.