### PR TITLE
Added Support for larger files 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0.202.1-3
+
+# Update the conda environment according to the environment.yml file in the project.
+COPY environment.yml /tmp/conda-tmp/
+RUN /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml && rm -rf /tmp/conda-tmp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/python-3-miniconda
+{
+	"name": "Miniconda (Python 3)",
+	"build": {
+		"context": "..",
+		"dockerfile": "Dockerfile",
+	},
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"python.defaultInterpreterPath": "/opt/conda/bin/python",
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"ms-toolsai.vscode-ai",
+	],
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"azure-cli": "latest"
+	},
+	"onCreateCommand": "az extension add -n ml -y"
+}

--- a/code/BatchPushResults/__init__.py
+++ b/code/BatchPushResults/__init__.py
@@ -39,14 +39,7 @@ def main(msg: func.QueueMessage) -> None:
                 set_document(e)
         else:
             set_document(data)
-        
-
-        # upsert_blob_metadata(file_name, {'embeddings_added': 'true'})
-
-        # Set the document in Redis, can be a list of embedding in case of larger file
-        for e in data:
-            set_document(e)
-        # set_document(data)
+            
     else:
         file_sas = generate_blob_sas(account_name, container_name, file_name, account_key= account_key, permission='r', expiry=datetime.utcnow() + timedelta(hours=1))
         convert_file_and_add_embeddings(f"https://{account_name}.blob.core.windows.net/{container_name}/{file_name}?{file_sas}" , file_name)

--- a/code/BatchPushResults/__init__.py
+++ b/code/BatchPushResults/__init__.py
@@ -32,8 +32,21 @@ def main(msg: func.QueueMessage) -> None:
         # Embed the file
         data = chunk_and_embed(file_content, file_name)
 
-        # Set the document in Redis
-        set_document(data)
+        # check if `data` is a list of embeddings or a single embedding
+        if isinstance(data, list):
+            # Set the document in Redis, can be a list of embedding in case of larger file
+            for e in data:
+                set_document(e)
+        else:
+            set_document(data)
+        
+
+        # upsert_blob_metadata(file_name, {'embeddings_added': 'true'})
+
+        # Set the document in Redis, can be a list of embedding in case of larger file
+        for e in data:
+            set_document(e)
+        # set_document(data)
     else:
         file_sas = generate_blob_sas(account_name, container_name, file_name, account_key= account_key, permission='r', expiry=datetime.utcnow() + timedelta(hours=1))
         convert_file_and_add_embeddings(f"https://{account_name}.blob.core.windows.net/{container_name}/{file_name}?{file_sas}" , file_name)

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pip
   - pip:
       - azure-functions
+      - tqdm
       - streamlit==1.17.0
       - openai==0.26.5
       - matplotlib==3.6.3

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ dependencies:
   - yapf
   - pylint
   - pip
+  - tqdm
   - pip:
       - azure-functions
-      - tqdm
       - streamlit==1.17.0
       - openai==0.26.5
       - matplotlib==3.6.3

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - yapf
   - pylint
   - pip
-  - tqdm
+  - tqdm=4.45.0
   - pip:
       - azure-functions
       - streamlit==1.17.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.8
+  - python=3.10
   - yapf
   - pylint
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,10 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.8
   - yapf
   - pylint
   - pip
-  - tqdm=4.45.0
   - pip:
       - azure-functions
       - streamlit==1.17.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,25 @@
+name: azureopenai
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python==3.8
+  - yapf
+  - pylint
+  - pip
+  - pip:
+      - azure-functions
+      - streamlit==1.17.0
+      - openai==0.26.5
+      - matplotlib==3.6.3
+      - plotly==5.12.0
+      - scipy==1.10.0
+      - scikit-learn==1.2.0
+      - transformers==4.25.1
+      - redis==4.4.2
+      - python-dotenv==0.21.0
+      - azure-ai-formrecognizer==3.2.0
+      - azure-storage-blob==12.14.1
+      - requests==2.28.2
+      - tiktoken==0.2.0
+      - azure-storage-queue==12.5.0


### PR DESCRIPTION
@ruoccofabrizio I have added support for larger files by splitting document using LangChain.

Tried to do that for all ways of import:
1) adding single/synchronously - updated utils
2) adding text only - updated `Add document` page (with generating of unique filename)
3) adding in batch - updated Azure Function `init.py` - needs to be propagated to docker (not tested)

I have also added possibility to run in GH Codespaces (devcontainer).