### PR TITLE
added quote() to filename

### DIFF
--- a/code/BatchPushResults/__init__.py
+++ b/code/BatchPushResults/__init__.py
@@ -36,6 +36,6 @@ def main(msg: func.QueueMessage) -> None:
         set_document(data)
     else:
         file_sas = generate_blob_sas(account_name, container_name, file_name, account_key= account_key, permission='r', expiry=datetime.utcnow() + timedelta(hours=1))
-        convert_file_and_add_embeddings(f"https://{account_name}.blob.core.windows.net/{container_name}/{file_name}?{file_sas}" , file_name)
+        convert_file_and_add_embeddings(f"https://{account_name}.blob.core.windows.net/{container_name}/{quote(file_name)}?{file_sas}" , file_name)
 
     upsert_blob_metadata(file_name, {'embeddings_added': 'true'})


### PR DESCRIPTION
As I had a problem with whitespaces in filenames in this line I include the solution. I belive that when uploading files by an UI it doesn't occure but when using the code standalone those white spaces needed to be handled.