### PR TITLE
Fix issues of non-ascii text encoding, splitting & display

### DIFF
--- a/code/pages/01_Add_Document.py
+++ b/code/pages/01_Add_Document.py
@@ -10,7 +10,7 @@ import uuid
 from redis.exceptions import ResponseError 
 
 def get_content_type_with_encoding(content_type, bytes_data):
-    # Add encoding to content_type to avoid requests module to set incorrect encoding of ISO-8859-1 for text (text/plain) and html (text/html) files
+    # Add text encoding to Azure blob content_type property for avoiding requests module setting incorrect ISO-8859-1 encoding for text (text/plain) and html (text/html) files
     if "text" in content_type:
         try:
             encoding = chardet.detect(bytes_data)['encoding']
@@ -20,10 +20,10 @@ def get_content_type_with_encoding(content_type, bytes_data):
                 return f"{content_type}; charset=utf-16"
             
             return f"{content_type}; charset={encoding}"
-        except Exception as e:
-            return content_type
-    else:
-        return content_type
+        except Exception:
+            pass
+
+    return content_type
     
 def upload_text_and_embeddings():
     file_name = f"{uuid.uuid4()}.txt"
@@ -84,9 +84,7 @@ try:
                 # Upload a new file
                 st.session_state['filename'] = uploaded_file.name
                 content_type = get_content_type_with_encoding(mimetypes.MimeTypes().guess_type(uploaded_file.name)[0], bytes_data)
-                    
                 st.session_state['file_url'] = llm_helper.blob_client.upload_file(bytes_data, st.session_state['filename'], content_type=content_type)
-
                 converted_filename = ''
                 if uploaded_file.name.endswith('.txt'):
                     # Add the text to the embeddings
@@ -120,9 +118,7 @@ try:
                 if st.session_state.get('filename', '') != up.name:
                     # Upload a new file
                     st.session_state['filename'] = up.name
-                    
                     content_type = get_content_type_with_encoding(mimetypes.MimeTypes().guess_type(up.name)[0], bytes_data)
-                    
                     st.session_state['file_url'] = llm_helper.blob_client.upload_file(bytes_data, st.session_state['filename'], content_type=content_type)
                     if up.name.endswith('.txt'):
                         # Add the text to the embeddings

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -7,7 +7,7 @@ plotly==5.12.0
 scipy==1.10.0
 scikit-learn==1.2.0
 transformers==4.25.1
-redis==4.5.3
+redis==4.5.4
 python-dotenv==1.0.0
 azure-ai-formrecognizer==3.2.0
 azure-storage-blob==12.14.1
@@ -18,3 +18,4 @@ langchain==0.0.125
 beautifulsoup4==4.12.0
 streamlit-chat==0.0.2.2
 fake-useragent==1.1.3
+chardet

--- a/code/utilities/helper.py
+++ b/code/utilities/helper.py
@@ -88,6 +88,12 @@ class LLMHelper:
         try:
             documents = self.document_loaders(source_url).load()
             docs = self.text_splitter.split_documents(documents)
+            
+            #remove hidden characters from begin and end (langchain TokenTextSplitter may split a non-ascii character in half)
+            pattern = re.compile(r'[\x00-\x1f\x7f\u0080-\u00a0\u2000-\u3000\ufff0-\uffff]')
+            for(doc) in docs:
+                doc.page_content = re.sub(pattern, '', doc.page_content)
+            
             keys = []
             for i, doc in enumerate(docs):
                 # Create a unique key for the document

--- a/code/utilities/helper.py
+++ b/code/utilities/helper.py
@@ -87,9 +87,18 @@ class LLMHelper:
     def add_embeddings_lc(self, source_url):
         try:
             documents = self.document_loaders(source_url).load()
+            
+            # Convert to UTF-8 encoding for non-ascii text
+            for(document) in documents:
+                try:
+                    if document.page_content.encode("iso-8859-1") == document.page_content.encode("latin-1"):
+                        document.page_content = document.page_content.encode("iso-8859-1").decode("utf-8", errors="ignore")
+                except:
+                    pass
+                
             docs = self.text_splitter.split_documents(documents)
             
-            #remove hidden characters from begin and end (langchain TokenTextSplitter may split a non-ascii character in half)
+            # Remove half non-ascii character from start/end of doc content (langchain TokenTextSplitter may split a non-ascii character in half)
             pattern = re.compile(r'[\x00-\x1f\x7f\u0080-\u00a0\u2000-\u3000\ufff0-\uffff]')
             for(doc) in docs:
                 doc.page_content = re.sub(pattern, '', doc.page_content)
@@ -115,7 +124,7 @@ class LLMHelper:
 
         # Upload the text to Azure Blob Storage
         converted_filename = f"converted/{filename}.txt"
-        source_url = self.blob_client.upload_file("\n".join(text), f"converted/{filename}.txt", content_type='text/plain')
+        source_url = self.blob_client.upload_file("\n".join(text), f"converted/{filename}.txt", content_type='text/plain; charset=utf-8')
 
         print(f"Converted file uploaded to {source_url} with filename {filename}")
         # Update the metadata to indicate that the file has been converted


### PR DESCRIPTION
Changes:

1.  Append charset of text file to content-type property of blob when uploading text files to Azure Storage (resolve issue of https://github.com/ruoccofabrizio/azure-open-ai-embeddings-qna/issues/33.)
2.  Remove half non-ascii character in start and end of text after splitting by TokenTextSplitter



