### PR TITLE
Setting altair < 5 as requirement

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,6 +1,7 @@
 azure-functions
 
 streamlit==1.20.0
+altair<5
 openai==0.27.2
 matplotlib==3.6.3
 plotly==5.12.0


### PR DESCRIPTION
Setting `altair < 5` as requirement. Without it running new images based on WebApp.Dockerfile will not work.